### PR TITLE
UI buttons are traversable and can have dependencies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -90,6 +90,7 @@
         "ranges": "cpp",
         "scoped_allocator": "cpp",
         "shared_mutex": "cpp",
-        "typeindex": "cpp"
+        "typeindex": "cpp",
+        "stacktrace": "cpp"
     }
 }

--- a/TrollsVsElves/include/AdvancementTree.h
+++ b/TrollsVsElves/include/AdvancementTree.h
@@ -1,0 +1,43 @@
+#ifndef ADVANCEMENT_TREE_H
+#define ADVANCEMENT_TREE_H
+
+#include <string>
+#include <vector>
+#include <json/json.h>
+#include <fstream>
+
+struct AdvancementNode
+{
+    std::string id;
+    std::string name;
+    AdvancementNode* parent;
+    std::vector<std::string> dependencies;
+    std::vector<AdvancementNode*> children;
+
+    AdvancementNode(AdvancementNode* _parent, std::string _id, std::string _name, std::vector<std::string> _dependencies):
+        parent(_parent), id(_id), name(_name), dependencies(_dependencies) {};
+
+    ~AdvancementNode()
+    {
+        for (int i = 0; i < children.size(); i++)
+            delete children[i];
+    };
+};
+
+class AdvancementTree
+{
+private:
+    AdvancementNode* root;
+
+    void parseNode(const Json::Value& json, AdvancementNode* parent);
+    void printNode(AdvancementNode* parent, std::string prefix);
+
+public:
+    AdvancementTree() = delete;
+    AdvancementTree(std::string filename);
+    ~AdvancementTree();
+
+    AdvancementNode* getRoot();
+};
+
+#endif

--- a/TrollsVsElves/include/Building.h
+++ b/TrollsVsElves/include/Building.h
@@ -4,6 +4,8 @@
 #include "structs.h"
 #include "imgui.h"
 #include "rlImGui.h"
+#include "AdvancementTree.h"
+#include "Signal.h"
 
 enum BuildStage { GHOST = 0, SCHEDULED, IN_PROGRESS, FINISHED };
 enum BuildingType { CASTLE, ROCK, COUNT };
@@ -25,19 +27,26 @@ private:
 
     bool selected;
     bool sold;
-    int level;
     bool canRecruit;
     bool recruiting;
 
     Cylinder rallyPoint;
 
+    AdvancementNode* advancement;
+    std::vector<std::string> lockedPromotions;
+
+    simpleSignal::Signal<void(std::string)>* promotionSignal;
+
+    void checkKeyboardPresses(std::vector<AdvancementNode*> children);
+    void handleButtonPressLogic(AdvancementNode* node);
+
 public:
     Building() = delete;
-    Building(Cube cube, BuildingType buildingType);
+    Building(Cube cube, BuildingType buildingType, AdvancementNode* options, simpleSignal::Signal<void(std::string)>* promotionSignal);
     ~Building();
 
     void draw();
-    void drawUIButtons(ImVec2 windowPadding, ImVec2 buttonSize);
+    void drawUIButtons(ImVec2 buttonSize, int nrOfButtons, int buttonsPerLine);
     void update();
 
     void scheduleBuild();
@@ -54,14 +63,17 @@ public:
 
     void sell();
     bool isSold();
-    void upgrade();
     bool isRecruiting();
     void setRecruiting(bool value);
 
-    int getLevel();
-
     Cylinder getRallyPoint();
     void setRallyPoint(Vector3 point);
+
+    std::vector<AdvancementNode*> getPossiblePromotions();
+    bool canBePromotedTo(AdvancementNode* promotion);
+    void promote(AdvancementNode* promotion);
+
+    void updateLockedPromotions(std::vector<std::string> lockedPromotions);
 };
 
 #endif

--- a/TrollsVsElves/include/BuildingManager.h
+++ b/TrollsVsElves/include/BuildingManager.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <deque>
+#include <unordered_set>
 
 #include "utils.h"
 #include "Layer.h"
@@ -24,6 +25,12 @@ private:
 
     std::vector<Entity*> entities;
 
+    std::map<BuildingType, AdvancementTree*> advancementTrees;
+    std::unordered_set<std::string> unlockedAdvancements;
+
+    simpleSignal::Signal<void(std::string)> promotionSignal;
+    void onPromotion(std::string promotion);
+
     void updateGhostBuilding();
 
     template<typename Container>
@@ -37,7 +44,6 @@ public:
     void draw();
     void update();
 
-    std::vector<Building*> getBuildings(); // TODO: prob remove this
     Building* raycastToBuilding();
     void removeBuilding(Building* building);
 
@@ -53,6 +59,8 @@ public:
     bool ghostBuildingExists();
 
     std::vector<Entity*> getEntities();
+
+    void updateLockedPromotions();
 };
 
 #endif

--- a/TrollsVsElves/include/Entity.h
+++ b/TrollsVsElves/include/Entity.h
@@ -60,7 +60,7 @@ public:
     MovementState getPreviousState();
 
     void select();
-    void deselect();
+    virtual void deselect();
     bool isSelected();
 
     void attach(Building* building);

--- a/TrollsVsElves/include/GameScreen.h
+++ b/TrollsVsElves/include/GameScreen.h
@@ -16,17 +16,6 @@
 #include <deque>
 #include <map>
 
-struct UIMapping
-{
-    KeyboardKey key = KEY_NULL;
-    std::string buttonText = "";
-
-    UIMapping(): key(), buttonText() {};
-
-    UIMapping(KeyboardKey _key, std::string _buttonText)
-        : key(_key), buttonText(_buttonText) {};
-};
-
 enum RaycastHitType {
     RAYCAST_HIT_TYPE_UI = 0,
     RAYCAST_HIT_TYPE_PLAYER,
@@ -49,8 +38,6 @@ class GameScreen: public BaseScreen
         std::vector<Entity*> selectedEntities;
 
         std::vector<Resource*> resources;
-
-        std::map<BuildingType, UIMapping> buildingTypeMappings;
 
         Player* player;
 

--- a/TrollsVsElves/include/Player.h
+++ b/TrollsVsElves/include/Player.h
@@ -2,17 +2,33 @@
 #define PLAYER_H
 
 #include "Entity.h"
+#include "BuildingManager.h"
+#include "AdvancementTree.h"
+
+#include <map>
+#include <functional>
 
 class Player : public Entity
 {
 private:
+    BuildingManager* buildingManager;
+
+    AdvancementTree* advancements;
+    AdvancementNode* currentAdvancements;
+
+    void checkKeyboardPresses(std::vector<AdvancementNode*> children);
+    void handleButtonPressLogic(AdvancementNode* node);
+
 public:
     Player() = delete;
-    Player(Capsule capsule, Vector3 speed);
+    Player(Capsule capsule, Vector3 speed, BuildingManager* buildingManager);
     ~Player();
 
     void draw();
+    void drawUIButtons(ImVec2 buttonSize, int nrOfButtons, int buttonsPerLine);
     void update();
+
+    void deselect() override;
 };
 
 #endif

--- a/TrollsVsElves/include/Signal.h
+++ b/TrollsVsElves/include/Signal.h
@@ -1,0 +1,68 @@
+#pragma once
+
+// yoinked from https://github.com/victorsummer/SimpleSignal
+
+#include <functional>
+#include <vector>
+
+namespace simpleSignal {
+template<int>
+struct memberFunctionPlaceholder {};
+}
+
+namespace std {
+    template<int N>
+    struct is_placeholder<simpleSignal::memberFunctionPlaceholder<N>> : std::integral_constant<int, N + 1> {};
+}
+
+namespace simpleSignal {
+
+template<int... Ns>
+struct int_sequence {};
+
+template<int N, int... Ns>
+struct make_int_sequence : make_int_sequence<N - 1, N - 1, Ns...> {};
+
+template<int... Ns>
+struct make_int_sequence<0, Ns...> : int_sequence<Ns...> {};
+
+template<class> class Signal;
+
+template<class ResultType, class... Args>
+class Signal<ResultType(Args...)> {
+public:
+    using CallbackType = std::function<ResultType(Args...)>;
+
+    Signal() {}
+    ~Signal() {}
+
+    void connect(const Signal::CallbackType &func) {
+        mCallbacks.emplace_back(std::move(func));
+    }
+
+    template<class T, class F>
+    void connect(T *object, const F &memberFunc) {
+        mCallbacks.emplace_back(constructMemberFunc(object, memberFunc, make_int_sequence<sizeof...(Args)>{}));
+    }
+
+    void disconnect() {
+        mCallbacks.clear();
+    }
+
+    void emit(Args... args) {
+        for (const auto &callback : mCallbacks) {
+            callback(std::forward<Args>(args)...);
+        }
+    }
+
+private:
+    template<class T, class F, int... Ns>
+    Signal::CallbackType constructMemberFunc(T *object, const F &memberFunc, int_sequence<Ns...>) const {
+        return std::bind(memberFunc, object, memberFunctionPlaceholder<Ns>{}...);
+    }
+
+private:
+    std::vector<Signal::CallbackType> mCallbacks;
+};
+
+}

--- a/TrollsVsElves/premake5.lua
+++ b/TrollsVsElves/premake5.lua
@@ -43,4 +43,5 @@ project (baseName)
     includedirs { "include" }
 
     link_raylib()
+    link_to("jsoncpp")
 -- To link to a lib use link_to("LIB_FOLDER_NAME")

--- a/TrollsVsElves/src/AdvancementTree.cpp
+++ b/TrollsVsElves/src/AdvancementTree.cpp
@@ -1,0 +1,75 @@
+#include "AdvancementTree.h"
+#include <cassert>
+
+AdvancementTree::AdvancementTree(std::string filename)
+{
+    std::ifstream file(filename);
+    if (!file.is_open())
+    {
+        printf("couldn't open file %s\n", filename.c_str());
+        assert(file.is_open());
+    }
+
+    Json::Value json;
+    Json::Reader reader;
+    bool parsingSuccessful = reader.parse(file, json);
+    file.close();
+
+    if (!parsingSuccessful)
+    {
+        printf("couldn't parse json file %s\n", filename.c_str());
+        assert(parsingSuccessful);
+    }
+
+    root = new AdvancementNode(nullptr, json["id"].asString(), json["name"].asString(), {});
+    for (const auto& child : json["children"])
+        parseNode(child, root);
+
+    if (false) // set to true to log tree structure
+        printNode(root, "  -  ");
+}
+
+AdvancementTree::~AdvancementTree()
+{
+    delete root;
+}
+
+void AdvancementTree::parseNode(const Json::Value& json, AdvancementNode* parent)
+{
+    std::vector<std::string> dependencies;
+    for (const auto& dependency : json["dependencies"])
+        dependencies.push_back(dependency.asString());
+
+    AdvancementNode* node = new AdvancementNode(
+        parent,
+        json["id"].asString(),
+        json["name"].asString(),
+        dependencies
+    );
+    parent->children.push_back(node);
+
+    for (const auto& child : json["children"])
+        parseNode(child, node);
+}
+
+void AdvancementTree::printNode(AdvancementNode* parent, std::string prefix)
+{
+    printf("%sId: %s\n", prefix.c_str(), parent->id.c_str());
+    printf("%sName: %s\n", prefix.c_str(), parent->name.c_str());
+
+    if (parent->dependencies.size())
+    {
+        printf("%sDependencies:\n", prefix.c_str());
+        for (auto dependency: parent->dependencies)
+            printf("%s%s\n", prefix.c_str(), dependency.c_str());
+    }
+
+
+    for (auto child: parent->children)
+        printNode(child, prefix + " - ");
+}
+
+AdvancementNode* AdvancementTree::getRoot()
+{
+    return root;
+}

--- a/TrollsVsElves/src/Building.cpp
+++ b/TrollsVsElves/src/Building.cpp
@@ -1,36 +1,50 @@
 #include "Building.h"
 
-Building::Building(Cube cube, BuildingType buildingType)
+Building::Building(
+    Cube cube,
+    BuildingType buildingType,
+    AdvancementNode* advancement,
+    simpleSignal::Signal<void(std::string)>* promotionSignal)
 {
+
     buildStage = GHOST;
 
     ghostColor = { 0, 121, 241, 100 };
     inProgressColor = { 255, 255, 255, 100 };
 
-    selected = false;
-    sold = false;
-    level = 1;
-    canRecruit = true;
-    recruiting = false;
-
-    buildTime = 0.1f;
-    // buildTime = 2.f;
-    buildTimer = 0.f;
-
+    this->promotionSignal = promotionSignal;
     this->cube = cube;
     this->buildingType = buildingType;
     cube.color = ghostColor;
 
-    targetColor = buildingType == ROCK ? Color{ 60, 60, 60, 255 } : BEIGE;
-    Vector3 targetColorHSL = ColorToHSV(targetColor);
-    selectedColor = ColorFromHSV(targetColorHSL.x, targetColorHSL.y, targetColorHSL.z - 0.2f);
+    selected = false;
+    sold = false;
+    recruiting = false;
+
+    buildTime = 0.2f;
+    buildTimer = 0.f;
 
     rallyPoint = Cylinder(Vector3Zero(), 0.8f, 20.f, 8, { 255, 255, 255, 128 });
+
+    this->advancement = advancement;
+
+    switch (buildingType)
+    {
+        case ROCK:
+            targetColor = Color{ 60, 60, 60, 255 };
+            canRecruit = false;
+            break;
+        case CASTLE:
+            targetColor = BEIGE;
+            canRecruit = true;
+            break;
+    }
+
+    Vector3 targetColorHSL = ColorToHSV(targetColor);
+    selectedColor = ColorFromHSV(targetColorHSL.x, targetColorHSL.y, targetColorHSL.z - 0.2f);
 }
 
-Building::~Building()
-{
-}
+Building::~Building() {}
 
 void Building::draw()
 {
@@ -40,17 +54,82 @@ void Building::draw()
         drawCylinder(rallyPoint);
 }
 
-void Building::drawUIButtons(ImVec2 windowPadding, ImVec2 buttonSize)
+void Building::drawUIButtons(ImVec2 buttonSize, int nrOfButtons, int buttonsPerLine)
 {
-    if (ImGui::Button("Upgrade", buttonSize))
-        upgrade();
-    ImGui::SameLine();
-    if (ImGui::Button("Sell", buttonSize))
-        sell();
-    if (canRecruit)
+    std::vector<AdvancementNode*> children = advancement->children;
+
+    AdvancementNode fillerButton = AdvancementNode(nullptr, "filler", "filler", {});
+    AdvancementNode sellButton = AdvancementNode(nullptr, "sell", "Sell", {});
+
+    int nrOfFillerButtons = nrOfButtons - children.size();
+    for (int i = 0; i < nrOfFillerButtons - 1; i++)
+        children.push_back(&fillerButton);  // add filler buttons between actual buttons and sell button
+    children.push_back(&sellButton);        // add sellButton last so its the last button
+
+    AdvancementNode* child = nullptr;
+    bool buttonWasPressed = false;
+    for (int i = 0; i < children.size(); i += buttonsPerLine)
     {
-        if (ImGui::Button("Recruit", buttonSize))
-            recruiting = true;
+        for (int j = 0; j < buttonsPerLine; j++)
+        {
+            child = children[i+j];
+
+            if (child->name == "filler")
+                ImGui::InvisibleButton(child->name.c_str(), buttonSize);
+            else
+            {
+                if (canBePromotedTo(child)) // push default colors
+                {
+                    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{0.26f, 0.59f, 0.98f, 0.40f});         // found in imgui_draw.cpp@201
+                    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4{0.26f, 0.59f, 0.98f, 1.00f});  // found in imgui_draw.cpp@202
+                    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4{0.06f, 0.53f, 0.98f, 1.00f});   // found in imgui_draw.cpp@203
+                }
+                else // push disabled colors
+                {
+                    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{0.83f, 0.32f, 0.32f, 0.4f});
+                    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4{0.83f, 0.32f, 0.32f, 0.7f});
+                    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4{0.83f, 0.32f, 0.32f, 1.00f});
+                }
+
+                if (ImGui::Button(child->name.c_str(), buttonSize))
+                {
+                    buttonWasPressed = true;
+                    if (child->id == "sell")
+                        sell();
+                    else if (canBePromotedTo(child))
+                        promote(child);
+                }
+
+                ImGui::PopStyleColor(3); // remove pushed colors
+            }
+
+            if (j != buttonsPerLine - 1) // apply on all except the last
+                ImGui::SameLine();
+        }
+    }
+
+    if (!buttonWasPressed)
+        checkKeyboardPresses(children);
+}
+
+void Building::checkKeyboardPresses(std::vector<AdvancementNode*> children)
+{
+    // check if any key between KEY_ONE -> KEY_ONE + children.size() was pressed
+    AdvancementNode* child = nullptr;
+    for (int i = 0; i < children.size(); i++)
+    {
+        child = children[i];
+        int keyNr = int(KEY_ONE) + i;
+        if (IsKeyPressed((KeyboardKey)keyNr))
+        {
+            if (child->name == "filler")
+                return;
+            else if (child->id == "sell")
+                sell();
+            else if (canBePromotedTo(child))
+                promote(child);
+            break;
+        }
     }
 }
 
@@ -84,6 +163,7 @@ void Building::build()
 {
     assert(buildStage == SCHEDULED); // sanity check
 
+    promotionSignal->emit(advancement->id);
     buildStage = IN_PROGRESS;
 }
 
@@ -136,11 +216,6 @@ bool Building::isSold()
     return sold;
 }
 
-void Building::upgrade()
-{
-    level += 1;
-}
-
 bool Building::isRecruiting()
 {
     return recruiting;
@@ -151,11 +226,6 @@ void Building::setRecruiting(bool value)
     recruiting = value;
 }
 
-int Building::getLevel()
-{
-    return level;
-}
-
 Cylinder Building::getRallyPoint()
 {
     return rallyPoint;
@@ -164,4 +234,26 @@ Cylinder Building::getRallyPoint()
 void Building::setRallyPoint(Vector3 point)
 {
     rallyPoint.position = point;
+}
+
+std::vector<AdvancementNode*> Building::getPossiblePromotions()
+{
+    return advancement->children;
+}
+
+bool Building::canBePromotedTo(AdvancementNode* promotion)
+{
+    return std::find(lockedPromotions.begin(), lockedPromotions.end(), promotion->id) == lockedPromotions.end();
+}
+
+void Building::promote(AdvancementNode* promotion)
+{
+    printf("'%s' got promoted to '%s'\n", advancement->id.c_str(), promotion->id.c_str());
+    advancement = promotion;
+    promotionSignal->emit(promotion->id);
+}
+
+void Building::updateLockedPromotions(std::vector<std::string> lockedPromotions)
+{
+    this->lockedPromotions = lockedPromotions;
 }

--- a/TrollsVsElves/src/Layer.cpp
+++ b/TrollsVsElves/src/Layer.cpp
@@ -151,7 +151,7 @@ std::vector<Vector2i> Layer::getCubeIndices(Cube cube)
     int halfY = maxY - maxY / 2;
 
     std::vector<Vector2i> indices;
-    if (!maxX && !halfX && !maxY && !halfY) // all 0
+    if (!maxX && !halfX && !maxY && !halfY)
         return std::vector<Vector2i>(1, worldPositionToIndex({ cube.position.x, 0.f, cube.position.z }));
 
     for (int y = -halfY; y < halfY; y++)

--- a/TrollsVsElves/src/Player.cpp
+++ b/TrollsVsElves/src/Player.cpp
@@ -1,7 +1,13 @@
 #include "Player.h"
 
-Player::Player(Capsule capsule, Vector3 speed)
-    : Entity(capsule, speed, PLAYER) {}
+Player::Player(Capsule capsule, Vector3 speed, BuildingManager* buildingManager)
+    : Entity(capsule, speed, PLAYER)
+{
+    this->buildingManager = buildingManager;
+
+    advancements = new AdvancementTree("player-dependencies.json");
+    currentAdvancements = advancements->getRoot();
+}
 
 Player::~Player() {}
 
@@ -10,7 +16,86 @@ void Player::draw()
     Entity::draw();
 }
 
+void Player::drawUIButtons(ImVec2 buttonSize, int nrOfButtons, int buttonsPerLine)
+{
+    std::vector<AdvancementNode*> children = currentAdvancements->children;
+
+    AdvancementNode fillerButton = AdvancementNode(nullptr, "filler", "filler", {});
+    AdvancementNode backButton = AdvancementNode(nullptr, "back", "Back", {});
+
+    int nrOfFillerButtons = nrOfButtons - children.size();
+    for (int i = 0; i < nrOfFillerButtons - 1; i++)
+        children.push_back(&fillerButton);      // add filler buttons between actual buttons and back button
+
+    if (currentAdvancements->parent)            // can go back from here
+        children.push_back(&backButton);        // add backButton last so its the last button
+    else
+        children.push_back(&fillerButton);      // can't go back from here so add another fillerButton
+
+    bool buttonWasPressed = false;
+    AdvancementNode* child = nullptr;
+    for (int i = 0; i < children.size(); i += buttonsPerLine)
+    {
+        for (int j = 0; j < buttonsPerLine; j++)
+        {
+            child = children[i+j];
+
+            if (child->name == "filler") // draw invisible button, don't care if its pressed or not
+                ImGui::InvisibleButton(child->name.c_str(), buttonSize);
+            else if (ImGui::Button(child->name.c_str(), buttonSize))
+            {
+                buttonWasPressed = true;
+                handleButtonPressLogic(child);
+            }
+
+            if (j != buttonsPerLine - 1) // apply on all except the last
+                ImGui::SameLine();
+        }
+    }
+
+    if (!buttonWasPressed)
+        checkKeyboardPresses(children);
+}
+
 void Player::update()
 {
     Entity::update();
+}
+
+void Player::checkKeyboardPresses(std::vector<AdvancementNode*> children)
+{
+    // check if any key between KEY_ONE -> KEY_ONE + children.size() was pressed
+    AdvancementNode* child = nullptr;
+    for (int i = 0; i < children.size(); i++)
+    {
+        child = children[i];
+        int keyNr = int(KEY_ONE) + i;
+        if (IsKeyPressed((KeyboardKey)keyNr))
+        {
+            handleButtonPressLogic(child);
+            break;
+        }
+    }
+}
+
+void Player::deselect()
+{
+    currentAdvancements = advancements->getRoot(); // reset tree to root if player gets deselected
+    Entity::deselect();
+}
+
+void Player::handleButtonPressLogic(AdvancementNode* node)
+{
+    if (node->id == "filler")
+        return;
+    else if (node->id == "back")
+        currentAdvancements = currentAdvancements->parent;
+    else if (node->id == "castle")
+        buildingManager->createNewGhostBuilding(CASTLE);
+    else if (node->id == "rock")
+        buildingManager->createNewGhostBuilding(ROCK);
+    else if (node->id == "blink")
+        printf("Blink is not implemented\n"); // TODO: later
+    else
+        currentAdvancements = node;
 }

--- a/castle-dependencies.json
+++ b/castle-dependencies.json
@@ -1,0 +1,27 @@
+{
+    "id": "castle",
+    "name": "Castle",
+    "dependencies": [],
+    "children": [
+        {
+            "id": "castle-1",
+            "name": "Castle 1",
+            "dependencies": ["castle"],
+            "children": [
+                {
+                    "id": "castle-2",
+                    "name": "Castle 2",
+                    "dependencies": ["castle-1"],
+                    "children": [
+                        {
+                            "id": "castle-3",
+                            "name": "Castle 3",
+                            "dependencies": ["castle-2", "rock-1"],
+                            "children": []
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/player-dependencies.json
+++ b/player-dependencies.json
@@ -1,0 +1,39 @@
+{
+    "id": "player",
+    "name": "Player",
+    "dependencies": [],
+    "children": [
+        {
+            "id": "build",
+            "name": "Build",
+            "dependencies": [],
+            "children": [
+                {
+                    "id": "castle",
+                    "name": "Castle",
+                    "dependencies": [],
+                    "children": []
+                },
+                {
+                    "id": "rock",
+                    "name": "Rock",
+                    "dependencies": [],
+                    "children": []
+                }
+            ]
+        },
+        {
+            "id": "spells",
+            "name": "Spells",
+            "dependencies": [],
+            "children": [
+                {
+                    "id": "blink",
+                    "name": "Blink",
+                    "dependencies": [],
+                    "children": []
+                }
+            ]
+        }
+    ]
+}

--- a/rock-dependencies.json
+++ b/rock-dependencies.json
@@ -1,0 +1,34 @@
+{
+    "id": "rock",
+    "name": "Rock",
+    "dependencies": [],
+    "children": [
+        {
+            "id": "rock-1",
+            "name": "Rock 1",
+            "dependencies": ["rock"],
+            "children": [
+                {
+                    "id": "rock-2",
+                    "name": "Rock 2",
+                    "dependencies": ["rock-1", "castle"],
+                    "children": [
+                        {
+                            "id": "rock-3",
+                            "name": "Rock 3",
+                            "dependencies": ["rock-2", "castle-1"],
+                            "children": [
+                                {
+                                    "id": "rock-4",
+                                    "name": "Rock 4",
+                                    "dependencies": ["rock-3", "castle-2"],
+                                    "children": []
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
* Added basic Signal class for decoupling message passing between Building -> BuildingManager
* Added advancements to buildings which can be traversed(promoted) if all dependencies are unlocked
* Added support for keypresses 1-9 to building UI buttons
* Added map of unlocked advancements in BuildingManager
* Moved Player UI buttons from GameScreen to Player
* Moved Player UI keypresses 1-9 from GameScreen to Player
* Added advancements to player which can be traversed up and down to do different things
* Added logic to color building upgrade buttons red if the building can't be promoted to the advancement
* Added filler buttons between actual buttons and static buttons (Sell for buildings, Back for player)
* Added function to check if promotions are locked for a building depending on already unlocked advancements
* Added class AdvancementTree which parses a json file and creates a tree structure from it
* Added dependency json files for player, castle and rock